### PR TITLE
Add firebase-admin to external node modules for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,9 +5,9 @@
 
 
 [functions]
-  external_node_modules = ["express"]
+  external_node_modules = ["express", "firebase-admin"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"


### PR DESCRIPTION
## Purpose
Fix deployment error on Netlify where contact form data submission was failing after deployment, despite working correctly on localhost and displaying properly on the dashboard.

## Code changes
- Added `firebase-admin` to the `external_node_modules` array in `netlify.toml`
- This ensures Firebase Admin SDK is properly bundled as an external dependency during Netlify function builds
- Removed trailing whitespace for cleaner configurationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fa64cf5e792642b2b29a97354c7f6f1a/vibe-den)

👀 [Preview Link](https://fa64cf5e792642b2b29a97354c7f6f1a-vibe-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fa64cf5e792642b2b29a97354c7f6f1a</projectId>-->
<!--<branchName>vibe-den</branchName>-->